### PR TITLE
Attach generated zip to GitHub Releases using GitHub Actions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,16 @@
+name: Package and Release
+
+on:
+  push:
+    tags: 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Packager
+        uses: BigWigsMods/packager@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    
+    env:
+      # CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      # WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Clone repository

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     env:
-      # CF_API_KEY: ${{ secrets.CF_API_KEY }}
-      # WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
-      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.TOKEN_FOR_UPLOAD }}
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
This is a github action configuration using the [BigWigs packager](https://github.com/BigWigsMods/packager/wiki/GitHub-Actions-workflow).

It creates an addon zip by reading the .pkgmeta file, and uploads it to GitHub Releases as an asset.

This properly solves #5 and #10.

If you provide your CurseForge api key as a secret to the action (CF_API_KEY), it will even automate releases on CurseForge when you tag them.