### PR TITLE
Fix anchor for the first filter button

### DIFF
--- a/QuestFrame.lua
+++ b/QuestFrame.lua
@@ -979,7 +979,7 @@ local function QuestFrame_Update()
 					filterButton:SetPoint("RIGHT", prevFilter, "LEFT", 5, 0)
 					filterButton:SetPoint("TOP", prevButton, "TOP", 0, 3)
 				else
-					filterButton:SetPoint("RIGHT", 1, 0)
+					filterButton:SetPoint("RIGHT", prevButton.ButtonText, -3, 0)
 					filterButton:SetPoint("TOP", prevButton, "TOP", 0, 3)
 				end
 


### PR DESCRIPTION
Some times the filter button would overlap with the header collapse button