### PR TITLE
Fixes

### DIFF
--- a/AngrierWorldQuests.toc
+++ b/AngrierWorldQuests.toc
@@ -6,7 +6,7 @@
 ## Author: GurliGebis
 ## X-Category: Quests & Leveling
 ## X-Curse-Packaged-Version: @project-version@
-## X-Curse-Project-Name: Battle Pet Completionist
+## X-Curse-Project-Name: Angrier World Quests
 ## X-Curse-Project-ID: 426990
 ## Category-enUS: Quests
 ## Category-deDE: Quests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix typo reading self.numbObjectives instead of self.numObjectives in tooltip, causing cached value to never be used.
 * Fix X-Curse-Project-Name in TOC file from "Battle Pet Completionist" to "Angrier World Quests".
 * Fix has_value() leaking into global namespace; move to _AngrierWorldQuests table.
+* Move C_QuestLog.GetQuestRewardCurrencies call outside filter loop in IsQuestRewardFiltered.
 
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 12.0.1-20260408-2
 * Fix FACTION_ORDER_MIDNIGHT using hash table instead of array, causing Midnight faction filter to be empty.
+* Fix typo reading self.numbObjectives instead of self.numObjectives in tooltip, causing cached value to never be used.
 
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 12.0.1-20260408-2
+* Fix FACTION_ORDER_MIDNIGHT using hash table instead of array, causing Midnight faction filter to be empty.
+
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Fix FACTION_ORDER_MIDNIGHT using hash table instead of array, causing Midnight faction filter to be empty.
 * Fix typo reading self.numbObjectives instead of self.numObjectives in tooltip, causing cached value to never be used.
 * Fix X-Curse-Project-Name in TOC file from "Battle Pet Completionist" to "Angrier World Quests".
+* Fix has_value() leaking into global namespace; move to _AngrierWorldQuests table.
 
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix X-Curse-Project-Name in TOC file from "Battle Pet Completionist" to "Angrier World Quests".
 * Fix has_value() leaking into global namespace; move to _AngrierWorldQuests table.
 * Move C_QuestLog.GetQuestRewardCurrencies call outside filter loop in IsQuestRewardFiltered.
+* Replace redundant QuestMapFrame:GetParent():GetMapID() calls with displayMapID parameter in IsQuestFiltered.
 
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 12.0.1-20260408-2
 * Fix FACTION_ORDER_MIDNIGHT using hash table instead of array, causing Midnight faction filter to be empty.
 * Fix typo reading self.numbObjectives instead of self.numObjectives in tooltip, causing cached value to never be used.
+* Fix X-Curse-Project-Name in TOC file from "Battle Pet Completionist" to "Angrier World Quests".
 
 # 12.0.1-20260408-1
 * Fix tooltip taint caused by reading QuestScrollFrame.Contents:GetWidth() from addon code; use hardcoded width constant instead.

--- a/Common/Helpers.lua
+++ b/Common/Helpers.lua
@@ -27,7 +27,7 @@
     ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 ]]
 
-function has_value (tab, val)
+function _AngrierWorldQuests.has_value(tab, val)
     for index, value in ipairs(tab) do
         if value == val then
             return true

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -177,10 +177,10 @@ do
     --region Midnight
     local CONTINENT_MIDNIGHT = 2537 -- Midnight main map
     local FACTION_ORDER_MIDNIGHT = {
-        [2696] = true, -- Amani Tribe
-        [2699] = true, -- The Singularity
-        [2704] = true, -- Hara'ti
-        [2710] = true, -- Silvermoon Court
+        2696, -- Amani Tribe
+        2699, -- The Singularity
+        2704, -- Hara'ti
+        2710, -- Silvermoon Court
     }
     local MAPS_MIDNIGHT = {
         [2395] = true, -- Eversong Woods

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -333,11 +333,13 @@ do
             positiveMatch = true
         end
 
+        local rewardCurrencies = C_QuestLog.GetQuestRewardCurrencies(questID)
+
         for key, _ in pairs(selectedFilters) do
             local filter = ConfigModule.Filters[key]
             if filter.preset == _AngrierWorldQuests.Constants.FILTERS.CURRENCY then
                 hasCurrencyFilter = true
-                for k, currencyInfo in ipairs(C_QuestLog.GetQuestRewardCurrencies(questID)) do
+                for k, currencyInfo in ipairs(rewardCurrencies) do
                     if filter.currencyID == currencyInfo.currencyID then
                         positiveMatch = true
                     end

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -463,7 +463,6 @@ do
             end
 
             if selectedFilters.ZONE then
-                local currentMapID = QuestMapFrame:GetParent():GetMapID()
                 local filterMapID = ConfigModule:Get("filterZone")
 
                 if filterMapID ~= 0 then
@@ -471,14 +470,14 @@ do
                         isQuestFiltered = false
                     end
                 else
-                    if info.mapID and info.mapID == currentMapID then
+                    if info.mapID and info.mapID == displayMapID then
                         isQuestFiltered = false
                     end
                 end
             end
 
             if selectedFilters.EMISSARY then
-                local mapID = QuestMapFrame:GetParent():GetMapID()
+                local mapID = displayMapID
 
                 if mapID == _AngrierWorldQuests.Constants.MAP_IDS.BROKENISLES then
                     mapID = _AngrierWorldQuests.Constants.MAP_IDS.DALARAN -- fix no emissary on broken isles continent map

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -308,6 +308,8 @@ do
     function DataModule:IsFilterOnCorrectMap(filter, mapID)
         local expansion = DataModule:GetExpansionByMapID(mapID)
 
+        local has_value = _AngrierWorldQuests.has_value
+
         if expansion == _AngrierWorldQuests.Enums.Expansion.LEGION and has_value(FILTERS_LEGION, filter) then
             return true
         elseif expansion == _AngrierWorldQuests.Enums.Expansion.BFA and has_value(FILTERS_BFA, filter) then

--- a/Modules/QuestFrame/QuestFrameTooltip.lua
+++ b/Modules/QuestFrame/QuestFrameTooltip.lua
@@ -249,7 +249,7 @@ do
         end
 
         local isThreat = C_QuestLog.IsThreatQuest(questID)
-        local numObjectives = self.numbObjectives or C_QuestLog.GetNumQuestObjectives(questID)
+        local numObjectives = self.numObjectives or C_QuestLog.GetNumQuestObjectives(questID)
         for objectiveIndex = 1, numObjectives do
             local objectiveText, _, finished = GetQuestObjectiveInfo(questID, objectiveIndex, false)
             if not (finished and isThreat) then


### PR DESCRIPTION
* Fix FACTION_ORDER_MIDNIGHT using hash table instead of array, causing Midnight faction filter to be empty.
* Fix typo reading self.numbObjectives instead of self.numObjectives in tooltip, causing cached value to never be used.
* Fix X-Curse-Project-Name in TOC file from "Battle Pet Completionist" to "Angrier World Quests".
* Fix has_value() leaking into global namespace; move to _AngrierWorldQuests table.
* Move C_QuestLog.GetQuestRewardCurrencies call outside filter loop in IsQuestRewardFiltered.
* Replace redundant QuestMapFrame:GetParent():GetMapID() calls with displayMapID parameter in IsQuestFiltered.